### PR TITLE
Enable display of purchase it button

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -541,7 +541,6 @@ class Folio extends AbstractAPI implements
     public function getHolding($bibId, array $patron = null, array $options = [])
     {
         $instance = $this->getInstanceByBibId($bibId);
-
         $query = [
             'query' => '(instanceId=="' . $instance->id
                 . '" NOT discoverySuppress==true)'
@@ -587,8 +586,9 @@ class Folio extends AbstractAPI implements
             $holdingCallNumberPrefix = $holding->callNumberPrefix ?? '';
 
             $holdingItems = iterator_to_array($this->getPagedResults('items', '/item-storage/items', $query));
+            $isPurchaseable = str_contains($holding->notes[0]->note, 'Purchase It For Me');
 
-            if (count($holdingItems) == 0) {
+            if (count($holdingItems) == 0 && $isPurchaseable) {
                 $callNumberData = $this->chooseCallNumber(
                     $holdingCallNumberPrefix,
                     $holdingCallNumber,

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -604,7 +604,7 @@ class Folio extends AbstractAPI implements
                     'number' => 0,
                     'barcode' => '',
                     'status' => null,
-                    'availability' => false,
+                    'availability' => true,
                     'is_holdable' => $this->isHoldable($locationName),
                     'holdings_notes'=> $hasHoldingNotes ? $holdingNotes : null,
                     'item_notes' => null,

--- a/themes/TAMU/js/gifm.js
+++ b/themes/TAMU/js/gifm.js
@@ -35,7 +35,11 @@ var buildButtons = function() {
           $.each(data.payload.HashMap,function(mfhd,buttonPresentation) {
             $.each(buttonPresentation.buttons,function(index,button) {
               let buttonHtml = '<a target="_blank" class="'+button.cssClasses+'" href="https://'+button.linkHref+'">'+button.linkText+'</a>';
-              $("#getit_"+button.itemKey+" .buttons").append(buttonHtml);
+              if (button.itemKey) {
+                $("#getit_"+button.itemKey+" .buttons").append(buttonHtml);
+              } else {
+                $("#getit_purchase .buttons").append(buttonHtml);
+              }
             });
           });
         }

--- a/themes/TAMU/js/gifm.js
+++ b/themes/TAMU/js/gifm.js
@@ -33,14 +33,16 @@ var buildButtons = function() {
         } else {
           $(".getit .buttons").html("");
           $.each(data.payload.HashMap,function(mfhd,buttonPresentation) {
-            $.each(buttonPresentation.buttons,function(index,button) {
-              let buttonHtml = '<a target="_blank" class="'+button.cssClasses+'" href="https://'+button.linkHref+'">'+button.linkText+'</a>';
-              if (button.itemKey) {
-                $("#getit_"+button.itemKey+" .buttons").append(buttonHtml);
-              } else {
-                $("#getit_purchase .buttons").append(buttonHtml);
-              }
-            });
+            if (buttonPresentation && buttonPresentation.buttons) {
+              $.each(buttonPresentation.buttons,function(index,button) {
+                let buttonHtml = '<a target="_blank" class="'+button.cssClasses+'" href="https://'+button.linkHref+'">'+button.linkText+'</a>';
+                if (button.itemKey) {
+                  $("#getit_"+button.itemKey+" .buttons").append(buttonHtml);
+                } else {
+                  $("#getit_purchase .buttons").append(buttonHtml);
+                }
+              });
+            }
           });
         }
       }).fail(function(xhr,status,error) {

--- a/themes/TAMU/templates/RecordTab/holdingsils.phtml
+++ b/themes/TAMU/templates/RecordTab/holdingsils.phtml
@@ -78,6 +78,7 @@ $sort_holding_id = array_column( $holding['items'], "holding_id" );
 $sort_enumeration_id = array_column( $holding['items'], "enumeration" );
 array_multisort($sort_holding_id, SORT_DESC, $sort_enumeration_id, SORT_ASC, $holding['items']);
 
+$isPurchaseable = ($holdings['total'] == 1 && str_contains($holding['textfields']['holdings_notes'][0], 'Purchase It For Me'));
 ?>
 <h3>
   <?php $locationTextEsc = $this->transEscWithPrefix('location_', $holding['location']); ?>
@@ -112,6 +113,11 @@ array_multisort($sort_holding_id, SORT_DESC, $sort_enumeration_id, SORT_ASC, $ho
         <?php foreach ($textFields as $current): ?>
           <?=$this->linkify($this->escapeHtml($current))?><br/>
         <?php endforeach; ?>
+        <?php
+          if ($textFieldName == 'holdings_notes' && $isPurchaseable) {
+            echo '<div class="getit" id="getit_purchase"></div>';
+          }
+        ?>
       </td>
     </tr>
   <?php endforeach; ?>


### PR DESCRIPTION
vufind requires a holding to have at least one item for the holdings section to display.

Our Purchase It Now records do not have any items.

The 'items' themselves are actually a hybrid of item data and holding data.

This PR carves out an exception for PIN records that builds and returns a 'fake' item containing the available holding data which makes vufind happy.

With that exception in place, slight tweaks to the holdings html and gifm js allow the Purchase It Now button to be displayed.