### PR TITLE
Update build.xml

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -276,7 +276,7 @@
           <not><available file="${srcdir}/downloads/solr-${solr_version}.tgz" /></not>
            <then>
             <mkdir dir="${srcdir}/downloads" />
-            <httpget url="http://archive.apache.org/dist/solr/solr/${solr_version}/solr-${solr_version}.tgz" dir="${srcdir}/downloads" />
+            <httpget url="https://archive.apache.org/dist/solr/solr/${solr_version}/solr-${solr_version}.tgz" dir="${srcdir}/downloads" />
           </then>
         </if>
         <!-- unpack the archive into solr/vendor -->


### PR DESCRIPTION
The URL for archive.apache.org now uses HTTPS instead of HTTP. Editing to bring into line with VuFind's main repo.