### PR TITLE
Revise error message

### DIFF
--- a/themes/TAMU/templates/error/index.phtml
+++ b/themes/TAMU/templates/error/index.phtml
@@ -1,0 +1,49 @@
+<?php
+  // Set page title.
+  $this->headTitle($this->translate('An error has occurred'));
+
+  $this->layout()->breadcrumbs = '<li class="active">Error</li>';
+?>
+<div class="alert alert-danger">
+  <p><?=$this->transEsc('An error has occurred')?></p>
+  <p><?=$this->transEsc($this->message)?></p>
+  <p>
+    <?=$this->transEsc('Please contact AskUs for assistance')?>
+    <br>
+    <?php $supportEmail = $this->escapeHtmlAttr($this->systemEmail()); ?>
+    <a href="mailto:<?=$supportEmail?>"><?=$supportEmail?></a>
+  </p>
+</div>
+
+<?php if ($this->showInstallLink): ?>
+  <h2><a href="<?=$this->url('install-home')?>"><?=$this->transEsc('auto_configure_title', [], 'Auto Configure')?></a></h2>
+  <?=$this->transEsc('auto_configure_description', [], 'If this is a new installation, you may be able to fix the error using VuFind\'s Auto Configure tool.')?>
+  <h2><a href="<?=$this->url('upgrade-home')?>"><?=$this->transEsc('Upgrade VuFind')?></a></h2>
+  <?=$this->transEsc('upgrade_description', [], 'If you are upgrading a previous VuFind version, you can load your old settings with this tool.')?>
+<?php endif; ?>
+
+<?php if (isset($this->display_exceptions) && $this->display_exceptions): ?>
+  <h2><?=$this->transEsc('Exception')?>:</h2>
+  <p>
+    <b><?=$this->transEsc('Message')?>:</b> <?=$this->escapeHtml($this->exception->getMessage())?>
+  </p>
+
+  <h2><?=$this->transEsc('Backtrace')?>:</h2>
+  <pre><?=$this->exception->getTraceAsString()?>
+  </pre>
+
+  <?php if ($e = $this->exception->getPrevious()): ?>
+    <h3>Previous exceptions:</h3>
+    <?php while($e): ?>
+        <h4><?=get_class($e)?></h4>
+        <p><?=$e->getMessage()?></p>
+        <pre><?=$e->getTraceAsString()?></pre>
+        <?php $e = $e->getPrevious(); ?>
+    <?php endwhile; ?>
+  <?php endif; ?>
+
+  <?php if (isset($this->request)): ?>
+    <h2><?=$this->transEsc('error_page_parameter_list_heading')?>:</h2>
+    <pre><?=$this->escapeHtml(var_export($this->request->getParams(), true))?></pre>
+  <?php endif; ?>
+<?php endif ?>

--- a/themes/TAMU/templates/error/loginForAccess.phtml
+++ b/themes/TAMU/templates/error/loginForAccess.phtml
@@ -1,0 +1,4 @@
+<?php // This can be used as a permission denied behavior; see example in permissionBehavior.ini... ?>
+<a class="login" href="<?=$this->url('myresearch-home')?>" rel="nofollow">
+  <strong><?=$this->transEsc('Login for full access')?></strong>
+</a>

--- a/themes/TAMU/templates/error/permissiondenied.phtml
+++ b/themes/TAMU/templates/error/permissiondenied.phtml
@@ -1,0 +1,25 @@
+<?php
+  // Set page title.
+  $this->headTitle($this->translate('permission_denied_title'));
+
+  // Disable top search box -- this page has a special layout.
+  $this->layout()->searchbox = false;
+
+  $this->layout()->breadcrumbs = '<li class="active">Error</li>';
+?>
+<div>
+  <h2><?=$this->transEsc('permission_denied_title')?></h2>
+  <p><?=$this->flashmessages()?></p>
+  <p>
+    <?=$this->transEsc('permission_denied')?>
+    <?php if (!empty($msg)): ?>
+      <div class="alert alert-danger"><?=$this->transEsc($msg)?></div>
+    <?php endif; ?>
+  </p>
+  <p>
+    <?=$this->transEsc('Please contact AskUs for assistance')?>
+    <br>
+    <?php $supportEmail = $this->escapeHtmlAttr($this->systemEmail()); ?>
+    <a href="mailto:<?=$supportEmail?>"><?=$supportEmail?></a>
+  </p>
+</div>

--- a/themes/TAMU/templates/error/unavailable.phtml
+++ b/themes/TAMU/templates/error/unavailable.phtml
@@ -1,0 +1,22 @@
+<?php
+  // Set page title.
+  $this->headTitle($this->translate('System Unavailable'));
+
+  // Disable top search box -- this page has a special layout.
+  $this->layout()->searchbox = false;
+
+  $this->layout()->breadcrumbs = '<li class="active">Error</li>';
+?>
+<div class="alert alert-warning">
+  <h2><?=$this->transEsc('System Unavailable')?></h2>
+  <p>
+    <?=$this->transEsc('The system is currently unavailable due to system maintenance')?>.
+    <?=$this->transEsc('Please check back soon')?>.
+  </p>
+  <p>
+    <?=$this->transEsc('Please contact AskUs for assistance')?>
+    <br>
+    <?php $supportEmail = $this->escapeHtmlAttr($this->systemEmail()); ?>
+    <a href="mailto:<?=$supportEmail?>"><?=$supportEmail?></a>
+  </p>
+</div>


### PR DESCRIPTION
Added a copy of the bootstrap3 theme's error folder to the TAMU theme folder, and changed the error message phrasing "Please contact the Library Reference Department for assistance" to "Please contact AskUs for assistance."