### PR TITLE
Add uniform title and language notes via TAMU module

### DIFF
--- a/module/TAMU/config/module.config.php
+++ b/module/TAMU/config/module.config.php
@@ -1,17 +1,39 @@
 <?php
-namespace TAMU\Module\Config;
 
-return [
-    'vufind' => [
-        'plugin_managers' => [
-            'ils_driver' => [
-                'factories' => [
-                    'TAMU\\ILS\\Driver\\Folio' => 'VuFind\\ILS\\Driver\\FolioFactory',
-                ],
-                'aliases' => [
-                    'VuFind\\ILS\\Driver\\Folio' => 'TAMU\\ILS\\Driver\\Folio',
-                ]
-            ],
-        ],
-    ],
-];
+return array (
+  'vufind' =>
+  array (
+    'plugin_managers' =>
+    array (
+      'ils_driver' =>
+      array (
+        'factories' =>
+        array (
+          'TAMU\\ILS\\Driver\\Folio' => 'VuFind\\ILS\\Driver\\FolioFactory',
+        ),
+        'aliases' =>
+        array (
+          'VuFind\\ILS\\Driver\\Folio' => 'TAMU\\ILS\\Driver\\Folio',
+        ),
+      ),
+      'recorddriver' =>
+      array (
+        'factories' =>
+        array (
+          'TAMU\\RecordDriver\\SolrMarc' => 'TAMU\\RecordDriver\\SolrDefaultFactory',
+        ),
+        'aliases' =>
+        array (
+          'VuFind\\RecordDriver\\SolrMarc' => 'TAMU\\RecordDriver\\SolrMarc',
+        ),
+        'delegators' =>
+        array (
+          'TAMU\\RecordDriver\\SolrMarc' =>
+          array (
+            0 => 'TAMU\\RecordDriver\\IlsAwareDelegatorFactory',
+          ),
+        ),
+      ),
+    ),
+  ),
+);

--- a/module/TAMU/src/TAMU/RecordDriver/DefaultRecord.php
+++ b/module/TAMU/src/TAMU/RecordDriver/DefaultRecord.php
@@ -40,13 +40,5 @@ namespace TAMU\RecordDriver;
  */
 class DefaultRecord extends \VuFind\RecordDriver\DefaultRecord
 {
-    /**
-     * Get an array of all the language notes associated with the record.
-     *
-     * @return array
-     */
-    public function getLanguageNote()
-    {
-        return (array)($this->fields['language-notes'] ?? []);
-    }
+
 }

--- a/module/TAMU/src/TAMU/RecordDriver/IlsAwareDelegatorFactory.php
+++ b/module/TAMU/src/TAMU/RecordDriver/IlsAwareDelegatorFactory.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace TAMU\RecordDriver;
+
+class IlsAwareDelegatorFactory extends \VuFind\RecordDriver\IlsAwareDelegatorFactory
+{
+}
+

--- a/module/TAMU/src/TAMU/RecordDriver/SolrDefaultFactory.php
+++ b/module/TAMU/src/TAMU/RecordDriver/SolrDefaultFactory.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace TAMU\RecordDriver;
+
+class SolrDefaultFactory extends \VuFind\RecordDriver\SolrDefaultFactory
+{
+}
+

--- a/module/TAMU/src/TAMU/RecordDriver/SolrMarc.php
+++ b/module/TAMU/src/TAMU/RecordDriver/SolrMarc.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace TAMU\RecordDriver;
+
+class SolrMarc extends \VuFind\RecordDriver\SolrMarc
+{
+    /**
+    * Get the uniform title from the 130a field
+    */
+    public function getUniformTitle()
+    {
+        return $this->fields['uniform_title_str_mv'] ?? [];
+    }
+
+    /**
+     * Get an array of all the language notes associated with the record.
+     *
+     * @return array
+     */
+    public function getLanguageNotes()
+    {
+        return (array)($this->fields['language-notes'] ?? []);
+    }
+}

--- a/module/TAMU/src/TAMU/View/Helper/Root/RecordDataFormatterFactory.php
+++ b/module/TAMU/src/TAMU/View/Helper/Root/RecordDataFormatterFactory.php
@@ -98,6 +98,13 @@ class RecordDataFormatterFactory extends
             ['itemPrefix' => '<span property="notesLanguage">',
              'itemSuffix' => '</span>']
         );
+        $spec->setLine(
+            'Language Notes',
+            'getLanguageNotes',
+            null,
+            ['itemPrefix' => '<span property="notesLanguage">',
+             'itemSuffix' => '</span>']
+        );
         $spec->setTemplateLine(
             'Published',
             'getPublicationDetails',

--- a/module/TAMU/src/TAMU/View/Helper/Root/RecordDataFormatterFactory.php
+++ b/module/TAMU/src/TAMU/View/Helper/Root/RecordDataFormatterFactory.php
@@ -93,13 +93,6 @@ class RecordDataFormatterFactory extends
         );
         $spec->setLine(
             'Language Notes',
-            'getLanguageNote',
-            null,
-            ['itemPrefix' => '<span property="notesLanguage">',
-             'itemSuffix' => '</span>']
-        );
-        $spec->setLine(
-            'Language Notes',
             'getLanguageNotes',
             null,
             ['itemPrefix' => '<span property="notesLanguage">',


### PR DESCRIPTION
Uses the 'extendclass' generator command described [here](https://vufind.org/wiki/development:code_generators) to generate and configure the needed class overrides in the TAMU module to expose Uniform Title and Language Notes in the Record view.

![uni-lang-example](https://github.com/user-attachments/assets/324525e6-1f51-42a6-b13f-6d5eaf053338)
