### PR TITLE
Move StackMap Script

### DIFF
--- a/themes/TAMU/templates/layout/layout.phtml
+++ b/themes/TAMU/templates/layout/layout.phtml
@@ -85,11 +85,7 @@ JS;
       }
     ?>
     <?=$this->headScript() ?>
-    <!-- STACKMAP CHANGES BEGIN HERE -->
-    <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-T8Gy5hrqNKT+hzMclPo118YTQO6cYprQmhrYwIiQ/3axmI1hQomh7Ud2hPOy8SP1" crossorigin="anonymous">
-    <script src="https://www.stackmapintegration.com/tamu-vufind/StackMap.min.js" type="text/javascript"></script>
-    <link rel="stylesheet" media="all" type="text/css" href="https://www.stackmapintegration.com/tamu-vufind/StackMap.min.css" />
-    <!-- STACKMAP CHANGES END HERE -->
+    
   </head>
   <body class="template-dir-<?=$this->templateDir?> template-name-<?=$this->templateName?> <?=$this->layoutClass('offcanvas-row')?><?php if ($this->layout()->rtl): ?> rtl<?php endif; ?>">
     <?php // Set up the search box -- there are three possible cases:
@@ -146,5 +142,10 @@ JS;
     <?php endforeach; ?>
 
     <?=$this->footScript() ?>
+    <!-- STACKMAP CHANGES BEGIN HERE -->
+    <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-T8Gy5hrqNKT+hzMclPo118YTQO6cYprQmhrYwIiQ/3axmI1hQomh7Ud2hPOy8SP1" crossorigin="anonymous">
+    <script src="https://www.stackmapintegration.com/tamu-vufind/StackMap.min.js" type="text/javascript"></script>
+    <link rel="stylesheet" media="all" type="text/css" href="https://www.stackmapintegration.com/tamu-vufind/StackMap.min.css" />
+    <!-- STACKMAP CHANGES END HERE -->
   </body>
 </html>


### PR DESCRIPTION
Addresses a problem where loading StackMap's JavaScript and CSS files cause a long lag in loading the catalog.

# Description

Moves StackMap script to the bottom of the layout instead of the top. This script appears to load slowly and delays loading the rest of the page.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing Procedures

This can be tested locally, but is also live on catalog-pre. Clear your browser's cache or use a private window, and load the home page. The page should render even while the JS/CSS are still loading.
