### PR TITLE
Fixed check_item_statuses.js

### DIFF
--- a/themes/TAMU5/js/check_item_statuses.js
+++ b/themes/TAMU5/js/check_item_statuses.js
@@ -1,233 +1,297 @@
-/*global Hunt, VuFind */
+/*global AjaxRequestQueue, VuFind */
 
 VuFind.register('itemStatuses', function ItemStatuses() {
-    function formatCallnumbers(callnumber, callnumber_handler) {
-      var cns = callnumber.split(',\t');
-      for (var i = 0; i < cns.length; i++) {
-        // If the call number has a special delimiter, it indicates a prefix that
-        // should be used for display but not for sorting/searching.
-        var actualCallNumber = cns[i];
-        var displayCallNumber = cns[i];
-        var parts = cns[i].split('::::');
-        if (parts.length > 1) {
-          displayCallNumber = parts[0] + " " + parts[1];
-          actualCallNumber = parts[1];
-        }
-        cns[i] = callnumber_handler
-          ? '<a href="' + VuFind.path + '/Alphabrowse/Home?source=' + encodeURI(callnumber_handler) + '&amp;from=' + encodeURI(actualCallNumber) + '">' + displayCallNumber + '</a>'
-          : displayCallNumber;
-      }
-      return cns.join(',\t');
-    }
-    function displayItemStatus(result, $item) {
-      $item.addClass('js-item-done').removeClass('js-item-pending');
-      $item.find('.status').empty().append(result.availability_message);
-      $item.find('.ajax-availability').removeClass('ajax-availability hidden');
-      if (typeof(result.error) != 'undefined'
-            && result.error.length > 0
-      ) {
-        $item.find('.callnumAndLocation').empty().addClass('text-danger').append(result.error);
-        $item.find('.callnumber,.hideIfDetailed,.location').addClass('hidden');
-      } else if (typeof(result.full_status) != 'undefined'
-            && result.full_status.length > 0
-            && $item.find('.callnumAndLocation').length > 0
-      ) {
-        // Full status mode is on -- display the HTML and hide extraneous junk:
-        $item.find('.callnumAndLocation').empty().append(result.full_status);
-        $item.find('.callnumber,.hideIfDetailed,.location,.status').addClass('hidden');
-      } else if (typeof(result.missing_data) !== 'undefined'
-            && result.missing_data
-      ) {
-        // No data is available -- hide the entire status area:
-        $item.find('.callnumAndLocation,.status').addClass('hidden');
-      } else if (result.locationList) {
-        // We have multiple locations -- build appropriate HTML and hide unwanted labels:
-        $item.find('.callnumber,.hideIfDetailed,.location').addClass('hidden');
-        var locationListHTML = "";
-        for (var x = 0; x < result.locationList.length; x++) {
-          locationListHTML += '<div class="groupLocation">';
-          if (result.locationList[x].availability) {
-            locationListHTML += '<span class="text-success"><i class="fa fa-ok" aria-hidden="true"></i> '
-                        + result.locationList[x].location + '</span> ';
-          } else if (typeof(result.locationList[x].status_unknown) !== 'undefined'
-                    && result.locationList[x].status_unknown
-          ) {
-            if (result.locationList[x].location) {
-              locationListHTML += '<span class="text-warning"><i class="fa fa-status-unknown" aria-hidden="true"></i> '
-                            + result.locationList[x].location + '</span> ';
-            }
-          } else {
-            locationListHTML += '<span class="text-danger"><i class="fa fa-remove" aria-hidden="true"></i> '
-                        + result.locationList[x].location + '</span> ';
-          }
-          locationListHTML += '</div>';
-          locationListHTML += '<div class="groupCallnumber">';
-          locationListHTML += (result.locationList[x].callnumbers)
-            ? formatCallnumbers(result.locationList[x].callnumbers, result.locationList[x].callnumber_handler) : '';
-          locationListHTML += '</div>';
-        }
-        $item.find('.locationDetails').removeClass('hidden');
-        $item.find('.locationDetails').html(locationListHTML);
-      } else {
-        // Default case -- load call number and location into appropriate containers:
+  var _checkItemHandlers = {};
+  var _handlerUrls = {};
 
-        //TAMU Customization - Separate each location for display
-        let locations = result.location.split(",\t");
-        let displayLocations = "";
-        if (locations.length > 1) {
-            $(locations).each(function(i,l) {
-                displayLocations += '<div>'+l+'</div>';
-            });
+  function formatCallnumbers(callnumber, callnumber_handler) {
+    var cns = callnumber.split(',\t');
+    for (var i = 0; i < cns.length; i++) {
+      // If the call number has a special delimiter, it indicates a prefix that
+      // should be used for display but not for sorting/searching.
+      var actualCallNumber = cns[i];
+      var displayCallNumber = cns[i];
+      var parts = cns[i].split('::::');
+      if (parts.length > 1) {
+        displayCallNumber = parts[0] + " " + parts[1];
+        actualCallNumber = parts[1];
+      }
+
+      cns[i] = callnumber_handler
+        ? '<a href="' + VuFind.path + '/Alphabrowse/Home?source=' + encodeURI(callnumber_handler) + '&amp;from=' + encodeURI(actualCallNumber) + '">' + displayCallNumber + '</a>'
+        : displayCallNumber;
+    }
+    return cns.join(',\t');
+  }
+
+  function displayItemStatus(result, el) {
+    el.querySelectorAll('.status').forEach((status) => {
+      status.innerHTML = typeof result.availability_message === "undefined" ? "" : result.availability_message;
+    });
+    el.querySelectorAll('.ajax-availability').forEach((ajaxAvailability) => {
+      ajaxAvailability.classList.remove('ajax-availability');
+      ajaxAvailability.classList.remove('hidden');
+    });
+
+    let callnumAndLocations = el.querySelectorAll('.callnumAndLocation');
+    if (typeof(result.error) != 'undefined'
+      && result.error.length > 0
+    ) {
+      callnumAndLocations.forEach((callnumAndLocation) => {
+        callnumAndLocation.innerHTML = result.error;
+        callnumAndLocation.classList.add('text-danger');
+      });
+      el.querySelectorAll('.callnumber,.hideIfDetailed,.location').forEach((e) => { e.classList.add('hidden'); });
+    } else if (typeof(result.full_status) != 'undefined'
+      && result.full_status.length > 0
+      && callnumAndLocations.length > 0
+    ) {
+      // Full status mode is on -- display the HTML and hide extraneous junk:
+      callnumAndLocations.forEach((callnumAndLocation) => {
+        VuFind.setElementContents(callnumAndLocation, VuFind.updateCspNonce(result.full_status));
+      });
+      el.querySelectorAll('.callnumber,.hideIfDetailed,.location,.status').forEach((e) => { e.classList.add('hidden'); });
+    } else if (typeof(result.missing_data) !== 'undefined'
+      && result.missing_data
+    ) {
+      // No data is available -- hide the entire status area:
+      el.querySelectorAll('.callnumAndLocation,.status').forEach((e) => e.classList.add('hidden'));
+    } else if (result.locationList) {
+      // We have multiple locations -- build appropriate HTML and hide unwanted labels:
+      el.querySelectorAll('.callnumber,.hideIfDetailed,.location').forEach((e) => e.classList.add('hidden'));
+      var locationListHTML = "";
+      for (var x = 0; x < result.locationList.length; x++) {
+        locationListHTML += '<div class="groupLocation">';
+        if (result.locationList[x].availability) {
+          locationListHTML += '<span class="text-success">'
+            + VuFind.icon("status-available")
+            + result.locationList[x].location
+            + '</span> ';
+        } else if (typeof(result.locationList[x].status_unknown) !== 'undefined'
+          && result.locationList[x].status_unknown
+        ) {
+          if (result.locationList[x].location) {
+            locationListHTML += '<span class="text-warning">'
+              + VuFind.icon("status-unknown")
+              + result.locationList[x].location
+              + '</span> ';
+          }
         } else {
-            displayLocations = result.location;
+          locationListHTML += '<span class="text-danger">'
+            + VuFind.icon("status-unavailable")
+            + result.locationList[x].location
+            + '</span> ';
         }
-        $item.find('.callnumber').empty().append(formatCallnumbers(result.callnumber, result.callnumber_handler) + '<br/>');
-        $item.find('.location').empty().append(
-          result.reserve === 'true'
-            ? result.reserve_message
-            : displayLocations
-        );
+        locationListHTML += '</div>';
+        locationListHTML += '<div class="groupCallnumber">';
+        locationListHTML += (result.locationList[x].callnumbers)
+          ? formatCallnumbers(result.locationList[x].callnumbers, result.locationList[x].callnumber_handler) : '';
+        locationListHTML += '</div>';
       }
+      el.querySelectorAll('.locationDetails').forEach((locationDetails) => {
+        locationDetails.classList.remove('hidden');
+        locationDetails.innerHTML = locationListHTML;
+      });
+    } else {
+      // Default case -- load call number and location into appropriate containers:
+      el.querySelectorAll('.callnumber').forEach((callnumber) => {
+        callnumber.innerHTML = formatCallnumbers(result.callnumber, result.callnumber_handler) + '<br>';
+      });
+      el.querySelectorAll('.location').forEach((location) => {
+        location.innerHTML = result.reserve === 'true'
+          ? result.reserve_message
+          : result.location;
+      });
+    }
+    el.classList.add('js-item-done');
+    el.classList.remove('js-item-pending');
+  }
+
+  function itemStatusAjaxSuccess(items, response) {
+    let idMap = {};
+
+    // make map of ids to element arrays
+    items.forEach(function mapItemId(item) {
+      if (typeof idMap[item.id] === "undefined") {
+        idMap[item.id] = [];
+      }
+
+      idMap[item.id].push(item.el);
+    });
+
+    // display data
+    response.json().then((body) => {
+      body.data.statuses.forEach(function displayItemStatusResponse(status) {
+        if (typeof idMap[status.id] === "undefined") {
+          return;
+        }
+        idMap[status.id].forEach((el) => displayItemStatus(status, el));
+      });
+      VuFind.emit("item-status-done");
+    });
+  }
+
+  function itemStatusAjaxFailure(items, response, textStatus) {
+    if (
+      textStatus === "error" ||
+      textStatus === "abort"
+    ) {
+      VuFind.emit("item-status-done");
+      return;
     }
 
-    var ItemStatusHandler = {
-      name: "default",
-      // Object that holds item IDs, states and elements
-      items: {},
-      url: '/AJAX/JSON?method=getItemStatuses',
-      itemStatusRunning: false,
-      dataType: 'json',
-      method: 'POST',
-      itemStatusTimer: null,
-      itemStatusDelay: 200,
-
-      checkItemStatusDone: function checkItemStatusDone(response) {
-        var data = response.data;
-        for (var j = 0; j < data.statuses.length; j++) {
-          var status = data.statuses[j];
-          this.items[status.id].result = status;
-          this.items[status.id].state = 'done';
-          for (var e = 0; e < this.items[status.id].elements.length; e++) {
-            displayItemStatus(status, this.items[status.id].elements[e]);
-          }
-        }
-      },
-      itemStatusFail: function itemStatusFail(response, textStatus) {
-        if (textStatus === 'error' || textStatus === 'abort' || typeof response.responseJSON === 'undefined') {
-          return;
-        }
-        // display the error message on each of the ajax status place holder
-        $('.js-item-pending .callnumAndLocation').addClass('text-danger').empty().removeClass('hidden')
-          .append(typeof response.responseJSON.data === 'string' ? response.responseJSON.data : VuFind.translate('error_occurred'));
-      },
-      itemQueueAjax: function itemQueueAjax(id, el) {
-        el.addClass('js-item-pending').removeClass('hidden');
-        el.find('.callnumAndLocation').removeClass('hidden');
-        el.find('.callnumAndLocation .ajax-availability').removeClass('hidden');
-        el.find('.status').removeClass('hidden');
-        // If this id has already been queued, just add it to the elements or display a
-        // cached result.
-        if (typeof this.items[id] !== 'undefined') {
-          if ('done' === this.items[id].state) {
-            displayItemStatus(this.items[id].result, el);
-          } else {
-            this.items[id].elements.push(el);
-          }
-          return;
-        }
-        clearTimeout(this.itemStatusTimer);
-        this.items[id] = {
-          id: id,
-          state: 'queued',
-          elements: [el]
-        };
-        this.itemStatusTimer = setTimeout(this.runItemAjaxForQueue.bind(this), this.itemStatusDelay);
-      },
-
-      runItemAjaxForQueue: function runItemAjaxForQueue() {
-        if (this.itemStatusRunning) {
-          this.itemStatusTimer = setTimeout(this.runItemAjaxForQueue.bind(this), this.itemStatusDelay);
-          return;
-        }
-        var ids = [];
-        var self = this;
-        $.each(this.items, function selectQueued() {
-          if ('queued' === this.state) {
-            self.items[this.id].state = 'running';
-            ids.push(this.id);
-          }
+    response.json().then((body) => {
+      // display the error message on each of the ajax status place holder
+      items.forEach(function displayItemStatusFailure(item) {
+        item.el.querySelectorAll(".callnumAndLocation").forEach((callNumAndLocation) => {
+          callNumAndLocation.classList.add("text-danger");
+          callNumAndLocation.innerHTML = "";
+          callNumAndLocation.classList.remove("hidden");
+          callNumAndLocation.innerHTML = typeof body.data === "string"
+            ? body.data
+            : VuFind.translate("error_occurred");
         });
-        $.ajax({
-          dataType: this.dataType,
-          method: this.method,
-          url: VuFind.path + this.url,
-          context: this,
-          data: { 'id': ids }
-        })
-          .done(this.checkItemStatusDone)
-          .fail( this.itemStatusFail)
-          .always(function queueAjaxAlways() {
-            this.itemStatusRunning = false;
-          });
-      }//end runItemAjaxForQueue
+      });
+    }).finally(() => {
+      VuFind.emit("item-status-done");
+    });
+  }
+
+  function getStatusUrl(handlerName) {
+    if (_handlerUrls[handlerName] !== undefined) {
+      return _handlerUrls[handlerName];
+    }
+    return "/AJAX/JSON?method=getItemStatuses";
+  }
+
+  function getItemStatusPromise({
+    handlerName = "ils",
+    acceptType = "application/json",
+    method = "POST",
+  } = {}) {
+    return function runFetchItem(items) {
+      let body = new URLSearchParams();
+      items.forEach((item) => {
+        body.append("id[]", item.id);
+      });
+      body.append("sid", VuFind.getCurrentSearchId());
+      return fetch(
+        VuFind.path + getStatusUrl(handlerName),
+        {
+          method: method,
+          headers: {
+            'Accept': acceptType,
+            'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
+          },
+          body: body
+        }
+      );
     };
+  }
 
-    //add you own overridden handler here
-    var OdItemStatusHandler = Object.create(ItemStatusHandler);
-    OdItemStatusHandler.url = '/Overdrive/getStatus';
-    OdItemStatusHandler.itemStatusDelay = 200;
-    OdItemStatusHandler.name = "overdrive";
-    OdItemStatusHandler.items = {};
+  function makeItemStatusQueue({
+    handlerName = "ils",
+    delay = 200,
+  } = {}) {
+    return new AjaxRequestQueue({
+      run: getItemStatusPromise({handlerName: handlerName}),
+      success: itemStatusAjaxSuccess,
+      failure: itemStatusAjaxFailure,
+      delay,
+    });
+  }
 
-    //store the handlers in a "hash" obj
-    var checkItemHandlers = {
-      'ils': ItemStatusHandler,
-      'overdrive': OdItemStatusHandler,
+  function checkItemStatus(el) {
+    const hiddenIdEl = el.querySelector(".hiddenId");
+
+    if (
+      hiddenIdEl === null ||
+      el.classList.contains("js-item-pending") ||
+      el.classList.contains("js-item-done")
+    ) {
+      return;
+    }
+
+    // update element to reflect lookup
+    el.classList.add("js-item-pending");
+    el.classList.remove("hidden");
+    const callnumAndLocationEl = el.querySelector(".callnumAndLocation");
+    if (callnumAndLocationEl) {
+      callnumAndLocationEl.classList.remove("hidden");
+    }
+    el.querySelectorAll(".callnumAndLocation .ajax-availability").forEach(
+      (ajaxEl) => ajaxEl.classList.remove("hidden")
+    );
+
+    const statusEl = el.querySelector(".status");
+    if (statusEl) {
+      statusEl.classList.remove("hidden");
+    }
+
+    // get proper handler
+    let handlerName = "ils";
+    if (el.dataset.handlerName) {
+      handlerName = el.dataset.handlerName;
+    } else {
+      const handlerNameEl = el.querySelector(".handler-name");
+
+      if (handlerNameEl !== null) {
+        handlerName = handlerNameEl.value;
+      }
+    }
+
+    // queue the element into the queue
+    let payload = { el, id: hiddenIdEl.value };
+    if (VuFind.config.get('item-status:load-batch-wise', true)) {
+      _checkItemHandlers[handlerName].add(payload);
+    } else {
+      let runFunc = getItemStatusPromise({handlerName: handlerName});
+      runFunc([payload])
+        .then((...res) => itemStatusAjaxSuccess([payload], ...res))
+        .catch((...error) => {
+          console.error(...error);
+          itemStatusAjaxFailure([payload], ...error);
+        });
+    }
+  }
+
+  function checkAllItemStatuses(container = document) {
+    const records = container.querySelectorAll(".ajaxItem");
+
+    if (records.length === 0) {
+      VuFind.emit("item-status-done");
+      return;
+    }
+
+    records.forEach(checkItemStatus);
+  }
+
+  function updateContainer(params) {
+    let container = params.container;
+    if (VuFind.isPrinting() || !(VuFind.config.get('item-status:load-observable-only', true))) {
+      checkAllItemStatuses(container);
+    } else {
+      VuFind.observerManager.createIntersectionObserver(
+        'itemStatuses',
+        checkItemStatus,
+        container.querySelectorAll('.ajaxItem')
+      );
+    }
+  }
+
+  function addHandler(handlerName, handlerUrl) {
+    _checkItemHandlers[handlerName] = makeItemStatusQueue({handlerName: handlerName});
+    _handlerUrls[handlerName] = handlerUrl;
+  }
+
+  function init() {
+    _checkItemHandlers = {
+      ils: makeItemStatusQueue()
     };
+    addHandler("overdrive", "/Overdrive/getStatus");
+    updateContainer({container: document});
+    VuFind.listen('results-init', updateContainer);
+  }
 
-    function checkItemStatus(el) {
-      var $item = $(el);
-      if ($item.hasClass('js-item-pending') || $item.hasClass('js-item-done')) {
-        return;
-      }
-      if ($item.find('.hiddenId').length === 0) {
-        return false;
-      }
-      var id = $item.find('.hiddenId').val();
-      var handlerName = 'ils';
-      if ($item.data("handler-name")) {
-        handlerName = $item.data("handler-name");
-      } else if ($item.find('.handler-name').length > 0) {
-        handlerName = $item.find('.handler-name').val();
-      }
-
-      //queue the element into the handler
-      checkItemHandlers[handlerName].itemQueueAjax(id, $item);
-    }
-
-    function checkItemStatuses(_container) {
-      var container = typeof _container === 'undefined'
-        ? document.body
-        : _container;
-
-      var ajaxItems = $(container).find('.ajaxItem');
-      for (var i = 0; i < ajaxItems.length; i++) {
-        checkItemStatus($(ajaxItems[i]));
-      }
-    }
-    function init(_container) {
-      if (typeof Hunt === 'undefined') {
-        checkItemStatuses(_container);
-      } else {
-        var container = typeof _container === 'undefined'
-          ? document.body
-          : _container;
-        new Hunt(
-          $(container).find('.ajaxItem').toArray(),
-          { enter: checkItemStatus }
-        );
-      }
-    }
-
-    return { init: init, check: checkItemStatuses, checkRecord: checkItemStatus };
-  });
+  return { init: init, addHandler: addHandler, check: checkAllItemStatuses, checkRecord: checkItemStatus };
+});


### PR DESCRIPTION
Upload fixed version of check_item_statuses.js. This fixes a problem where RTAC data does not load in the search results page after changing the sort method. It is tested and working on PRE.
