### PR TITLE
Fix header link

### DIFF
--- a/themes/TAMU5/templates/header.phtml
+++ b/themes/TAMU5/templates/header.phtml
@@ -6,7 +6,7 @@
 
 <div class="col-sm-9 col-xs-11 logoLock">
   <div class="libLogo"></div>
-  <div class="nameBrand"><a class="navbar-brand lang-<?=$this->layout()->userLang ?>" href="<?=$this->url('home')?>">Texas A&amp;M University Libraries</a></div>
+  <div class="nameBrand"><a class="navbar-brand lang-<?=$this->layout()->userLang ?>" href="https://library.tamu.edu/">Texas A&amp;M University Libraries</a></div>
 </div>
 
 


### PR DESCRIPTION
# Description

Corrects the link in the header to go to the Libraries' home page instead of the catalog home page.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing Procedures

This change works as expected on PRE.
