### PR TITLE
Add GIFM Button support to the search results page

### DIFF
--- a/themes/TAMU5/js/check_item_statuses.js
+++ b/themes/TAMU5/js/check_item_statuses.js
@@ -51,6 +51,25 @@ VuFind.register('itemStatuses', function ItemStatuses() {
         VuFind.setElementContents(callnumAndLocation, VuFind.updateCspNonce(result.full_status));
       });
       el.querySelectorAll('.callnumber,.hideIfDetailed,.location,.status').forEach((e) => { e.classList.add('hidden'); });
+      // Begin TAMU Customization - Retrieve and inject GIFM buttons on search results page
+      fetch(gifmBase+"catalog-access/get-buttons?bibId="+result.id+"&catalogName="+catalogName)
+        .then(test => test.json())
+        .then(data => {
+          if (data.payload.HashMap) {
+            for (const [holdingId, buttonsData] of Object.entries(data.payload.HashMap)) {
+              if (buttonsData) {
+                let buttonHtml = "";
+                buttonsData.buttons.forEach(button => {
+                  buttonHtml += '<a target="_blank" class="'+button.cssClasses+'" href="https://'+button.linkHref+'">'+button.linkText+'</a>';
+                });
+
+                el.querySelector('#getit_'+holdingId).innerHTML = buttonHtml;
+              }
+            }
+          }
+        }
+      );
+      // End TAMU Customization - Retrieve and inject GIFM buttons on search results page
     } else if (typeof(result.missing_data) !== 'undefined'
       && result.missing_data
     ) {

--- a/themes/TAMU5/js/check_item_statuses.js
+++ b/themes/TAMU5/js/check_item_statuses.js
@@ -53,7 +53,7 @@ VuFind.register('itemStatuses', function ItemStatuses() {
       el.querySelectorAll('.callnumber,.hideIfDetailed,.location,.status').forEach((e) => { e.classList.add('hidden'); });
       // Begin TAMU Customization - Retrieve and inject GIFM buttons on search results page
       fetch(gifmBase+"catalog-access/get-buttons?bibId="+result.id+"&catalogName="+catalogName)
-        .then(test => test.json())
+        .then(response => response.json())
         .then(data => {
           if (data.payload.HashMap) {
             for (const [holdingId, buttonsData] of Object.entries(data.payload.HashMap)) {

--- a/themes/TAMU5/templates/RecordDriver/DefaultRecord/result-list.phtml
+++ b/themes/TAMU5/templates/RecordDriver/DefaultRecord/result-list.phtml
@@ -1,4 +1,6 @@
 <?php
+  // TAMU Customization - Add config for use by check_item_statuses.js GIFM js
+  $this->headScript()->appendFile("tamu_config.js");
   $coverDetails = $this->record($this->driver)->getCoverDetails('result-list', 'medium', $this->recordLinker()->getUrl($this->driver));
   $cover = $coverDetails['html'];
   $thumbnail = false;

--- a/themes/TAMU5/templates/ajax/status-full.phtml
+++ b/themes/TAMU5/templates/ajax/status-full.phtml
@@ -1,0 +1,68 @@
+<table class="table table-condensed">
+  <tr>
+    <th><?=$this->transEsc('Location')?></th>
+    <th><?=$this->transEsc('Call Number')?></th>
+    <th><?=$this->transEsc('Status')?></th>
+  </tr>
+  <?php $i = 0; ?>
+  <?php foreach ($this->statusItems as $item): ?>
+    <?php
+      if (++$i == 5) {
+        // Show no more than 5 items
+        break;
+      }
+      $callNumPrefix = !empty($item['callnumber_prefix']) ? $item['callnumber_prefix'] . ' ' : '';
+
+      $itemHasAdditionalHoldingsFields = false;
+      foreach ($this->holdingsTextFieldNames as $holdingsTextField) {
+        if (!empty($item[$holdingsTextField])) {
+          $itemHasAdditionalHoldingsFields = true;
+          break;
+        }
+      }
+    ?>
+    <tr<?=$itemHasAdditionalHoldingsFields ? $this->htmlAttributes(['class' => 'itemWithAdditionalHoldingFields']) : ''?>>
+      <td class="fullLocation">
+        <?php $locationText = $this->transEscWithPrefix('location_', $item['location']); ?>
+        <?php if ($item['locationhref'] ?? false): ?>
+          <a href="<?=$item['locationhref']?>" target="_blank"><?=$locationText?></a>
+        <?php else: ?>
+          <?=$locationText?>
+        <?php endif; ?>
+      </td>
+      <td class="fullCallnumber">
+        <?php if ($this->callnumberHandler): ?>
+          <a href="<?=$this->url('alphabrowse-home') ?>?source=<?=$this->escapeHtmlAttr($this->callnumberHandler) ?>&amp;from=<?=$this->escapeHtmlAttr($item['callnumber']) ?>"><?=$this->escapeHtml($callNumPrefix)?><?=$this->escapeHtml($item['callnumber'])?></a>
+        <?php else: ?>
+          <?=$this->escapeHtml($callNumPrefix)?><?=$this->escapeHtml($item['callnumber'])?>
+        <?php endif; ?>
+      </td>
+      <td class="fullAvailability">
+        <?php $availabilityStatus = $item['availability']; ?>
+          <?php
+            $statusClass = $this->availabilityStatus()->getClass($availabilityStatus);
+            if ($availabilityStatus->isAvailable() && $item['reserve'] === 'Y') {
+              $statusDescription = 'On Reserve';
+            } else {
+              $statusDescription = $availabilityStatus->getStatusDescription();
+            }
+            $statusDescriptionTokens = $availabilityStatus->getStatusDescriptionTokens();
+          ?>
+          <span class="<?=$this->escapeHtmlAttr($statusClass)?>"><?=$this->transEsc($statusDescription, $statusDescriptionTokens)?></span>
+      </td>
+    </tr>
+
+    <?php foreach ($this->holdingsTextFieldNames as $holdingsTextField): ?>
+      <?php if (!empty($item[$holdingsTextField])): ?>
+        <tr>
+          <td colspan="3" class="statusItemsHoldingsTextFields">
+            <strong><?= $this->transEsc(ucfirst($holdingsTextField)) ?>: </strong><span><?= $this->escapeHtml(implode('; ', ((array)$item[$holdingsTextField]))); ?></span>
+          </td>
+        </tr>
+      <?php endif; ?>
+    <?php endforeach; ?>
+  <?php endforeach; ?>
+<?php if (count($this->statusItems) > 5): ?>
+  <tr><td colspan="3"><a href="<?=$this->url('record', ['id' => $this->statusItems[0]['id']], ['query' => ['sid' => $this->searchId]])?>"><?=count($this->statusItems) - 5?> <?=$this->transEsc('more_ellipsis')?></a></td></tr>
+<?php endif; ?>
+</table>

--- a/themes/TAMU5/templates/ajax/status-full.phtml
+++ b/themes/TAMU5/templates/ajax/status-full.phtml
@@ -49,6 +49,8 @@
             $statusDescriptionTokens = $availabilityStatus->getStatusDescriptionTokens();
           ?>
           <span class="<?=$this->escapeHtmlAttr($statusClass)?>"><?=$this->transEsc($statusDescription, $statusDescriptionTokens)?></span>
+          <!-- TAMU Customization - Provide getit element for check_item_status.js GIFM injection -->
+          <div id="getit_<?=$item['holding_hrid']?>" class="getit"></div>
       </td>
     </tr>
 

--- a/themes/TAMU5/templates/ajax/status-full.phtml
+++ b/themes/TAMU5/templates/ajax/status-full.phtml
@@ -3,6 +3,7 @@
     <th><?=$this->transEsc('Location')?></th>
     <th><?=$this->transEsc('Call Number')?></th>
     <th><?=$this->transEsc('Status')?></th>
+    <th><?=$this->transEsc('Get It')?></th>
   </tr>
   <?php $i = 0; ?>
   <?php foreach ($this->statusItems as $item): ?>
@@ -49,6 +50,8 @@
             $statusDescriptionTokens = $availabilityStatus->getStatusDescriptionTokens();
           ?>
           <span class="<?=$this->escapeHtmlAttr($statusClass)?>"><?=$this->transEsc($statusDescription, $statusDescriptionTokens)?></span>
+      </td>
+      <td>
           <!-- TAMU Customization - Provide getit element for check_item_status.js GIFM injection -->
           <div id="getit_<?=$item['holding_hrid']?>" class="getit"></div>
       </td>


### PR DESCRIPTION
This may need further style tweaking, and there could be additional views that need the button check.

This approach piggybacks onto the check_item_statuses javascript, which allows us to take advantage of pre-existing Vufind functionality to efficiently queue the ajax calls as the user scrolls the results.


<img width="1245" height="1305" alt="Screenshot 2025-09-26 140958" src="https://github.com/user-attachments/assets/c47daa16-398f-4787-a3ec-e6ea8df91011" />
