### PR TITLE
Separate and display Volume/Enumeration in search results

### DIFF
--- a/themes/TAMU5/js/check_item_statuses.js
+++ b/themes/TAMU5/js/check_item_statuses.js
@@ -58,12 +58,10 @@ VuFind.register('itemStatuses', function ItemStatuses() {
           if (data.payload.HashMap) {
             for (const [holdingId, buttonsData] of Object.entries(data.payload.HashMap)) {
               if (buttonsData) {
-                let buttonHtml = "";
                 buttonsData.buttons.forEach(button => {
-                  buttonHtml += '<a target="_blank" class="'+button.cssClasses+'" href="https://'+button.linkHref+'">'+button.linkText+'</a>';
+                  let buttonHtml = '<a target="_blank" class="'+button.cssClasses+'" href="https://'+button.linkHref+'">'+button.linkText+'</a>';
+                  el.querySelector("#getit_"+holdingId+"_"+button.itemKey).innerHTML = buttonHtml;
                 });
-
-                el.querySelector('#getit_'+holdingId).innerHTML = buttonHtml;
               }
             }
           }

--- a/themes/TAMU5/templates/ajax/status-full.phtml
+++ b/themes/TAMU5/templates/ajax/status-full.phtml
@@ -6,7 +6,13 @@
     <th><?=$this->transEsc('Get It')?></th>
   </tr>
   <?php $i = 0; ?>
-  <?php foreach ($this->statusItems as $item): ?>
+  <?php
+    //TAMU Customization - Sort holding item's by enumeration
+    $statusItems = $this->statusItems;
+    $enumerations = array_column($statusItems, 'enumeration');
+    array_multisort($enumerations, SORT_ASC, SORT_NATURAL, $statusItems);
+  ?>
+  <?php foreach ($statusItems as $item): ?>
     <?php
       if (++$i == 5) {
         // Show no more than 5 items
@@ -37,6 +43,13 @@
         <?php else: ?>
           <?=$this->escapeHtml($callNumPrefix)?><?=$this->escapeHtml($item['callnumber'])?>
         <?php endif; ?>
+        <?php
+        //TAMU Customization - expose volume/enumeration info
+        if ($item['enumeration']): ?>
+          <?=$this->escapeHtml($item['enumeration'])?>
+        <?php
+        endif;
+        ?>
       </td>
       <td class="fullAvailability">
         <?php $availabilityStatus = $item['availability']; ?>
@@ -53,7 +66,7 @@
       </td>
       <td>
           <!-- TAMU Customization - Provide getit element for check_item_status.js GIFM injection -->
-          <div id="getit_<?=$item['holding_hrid']?>" class="getit"></div>
+          <div id="getit_<?=$item['holding_hrid']?>_<?=$item['item_hrid']?>" class="getit"></div>
       </td>
     </tr>
 


### PR DESCRIPTION
Sorts items by volume within a holding's item list, displays the volume info with the call number, and matches the GIFM buttons to their specific volume's row.

<img width="818" height="280" alt="Screenshot 2025-10-09 153318" src="https://github.com/user-attachments/assets/af153e92-1e1c-4568-87f1-6b7e137c73d7" />
